### PR TITLE
Fix ``launch configuration 'start_quadruped_controller' does not exist`` error

### DIFF
--- a/champ_bringup/launch/spot_spawn.launch.py
+++ b/champ_bringup/launch/spot_spawn.launch.py
@@ -21,9 +21,9 @@ def evaluate_nodes(context, *args, **kwargs):
 
   urdf_path = LaunchConfiguration("urdf_file").perform(context)
   mapping_dict = LaunchConfiguration("urdf_mapping").perform(context)
-  mapping_yaml = yaml.safe_load(mapping_dict) 
+  mapping_yaml = yaml.safe_load(mapping_dict)
 
-  robot_description = xacro.process_file( 
+  robot_description = xacro.process_file(
      urdf_path, mappings=mapping_yaml).toprettyxml(indent="  ")
 
   robot_state_publisher_node = Node(
@@ -36,7 +36,7 @@ def evaluate_nodes(context, *args, **kwargs):
                     ('/tf_static', 'tf_static')],
         output='screen'
   )
-  
+
   return [robot_state_publisher_node]
 
 ##################################################################
@@ -55,19 +55,19 @@ def generate_launch_description():
     DeclareLaunchArgument(
         'y',
         default_value='0.0',
-        description='y at which to spawn Spot.'), 
+        description='y at which to spawn Spot.'),
     DeclareLaunchArgument(
         'z',
         default_value='0.84',
-        description='Height at which to spawn Spot.'), 
+        description='Height at which to spawn Spot.'),
     DeclareLaunchArgument(
         'roll',
         default_value='0.0',
-        description='Roll at which to spawn Spot.'),  
+        description='Roll at which to spawn Spot.'),
     DeclareLaunchArgument(
         'yaw',
         default_value='-0.5',
-        description='Yaw at which to spawn Spot.'),          
+        description='Yaw at which to spawn Spot.'),
     DeclareLaunchArgument(
         'use_simulator',
         default_value='True',
@@ -86,16 +86,16 @@ def generate_launch_description():
             get_package_share_directory('champ_bringup'), 'config', 'robot_localization_params.yaml'),
         description='Path to the vox_nav parameters file.'),
     DeclareLaunchArgument(
-      'start_quadruped_controller', default_value='False')
+        'start_quadruped_controller', default_value='False')
   ]
-  
+
   use_simulator = LaunchConfiguration('use_simulator')
   use_sim_time = LaunchConfiguration('use_sim_time', default=True)
   tf_prefix = LaunchConfiguration('tf_prefix')
-    
+
   # Robot publisher
   nodes_eval = OpaqueFunction(function=evaluate_nodes)
-    
+
   # Bridge
   bridge_config_file = os.path.join(get_package_share_directory('champ_bringup'), 'config', "spot_bridge.yaml")
 
@@ -114,16 +114,16 @@ def generate_launch_description():
         arguments=['-name', 'spot',
                    '-topic', '/robot_description',
                     "-x", LaunchConfiguration("x"),
-                    "-y", LaunchConfiguration("y"),                     
+                    "-y", LaunchConfiguration("y"),
                    "-z", LaunchConfiguration("z"),
                    "-R", LaunchConfiguration("roll"),
                    "-Y", LaunchConfiguration("yaw"),
                   ],
         parameters=[{"use_sim_time": use_sim_time}],
         output='screen',
-        condition=IfCondition(use_simulator)        
+        condition=IfCondition(use_simulator)
   )
-  
+
   # Fix up the robot's ground truth to publish w.r.t. world
   # by default it is published w.r.t. the world's name, rather than "world"
   ground_truth_node = Node(
@@ -133,7 +133,7 @@ def generate_launch_description():
         output="screen",
         parameters=[{"robot_pose_topic": "/model/spot/pose", "fixed_frame": "world", "robot_frame": LaunchConfiguration("robot_base_link")}]
   )
-  
+
 
   load_joint_state_controller = Node(
         package="controller_manager",
@@ -177,14 +177,13 @@ def generate_launch_description():
 
   # Start quadruped controller
   launch_quadruped_controller = IncludeLaunchDescription(
-            PathJoinSubstitution([FindPackageShare('champ_bringup'), 'launch', 'spot_quadruped_controller.launch.py']),
-            condition=IfCondition(LaunchConfiguration("start_quadruped_controller"))
+        PathJoinSubstitution([FindPackageShare('champ_bringup'), 'launch', 'spot_quadruped_controller.launch.py'])
   )
-    
+
   return LaunchDescription(
-    launch_args + 
+    launch_args +
     [
-      SetParameter(name='use_sim_time', value=True), 
+      SetParameter(name='use_sim_time', value=True),
       nodes_eval,
       bridge,
       spawn_entity_to_gazebo_node,
@@ -205,7 +204,8 @@ def generate_launch_description():
           event_handler=OnProcessExit(
               target_action=load_joint_trajectory_controller,
               on_exit=[launch_quadruped_controller],
-          )
+          ),
+          condition=IfCondition(LaunchConfiguration("start_quadruped_controller"))
       ),
       odom_republish_node
     ])

--- a/champ_bringup/package.xml
+++ b/champ_bringup/package.xml
@@ -15,6 +15,7 @@
   <depend>std_msgs</depend>
   <depend>twist_mux</depend>
   <depend>champ_description</depend>
+  <depend>champ_base</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Running 
```bash
ros2 launch --debug craftsman_robots spot_demo.launch.py gz_sim:=true
```
produces the following error

```bash
launch.substitutions.substitution_failure.SubstitutionFailure: launch configuration 'start_quadruped_controller' does not exist
```

I suspect this is a bug in how launch arguments aren't correctly passing through the ``RegisterEventHandler`` action wrapper to the ``launch_quadruped_controller``.
For now, instead of applying the condition to ``launch_quadruped_controller``, applying the condition to the ``RegisterEventHandler`` works around the issue.

---

Full error message:

```bash
[DEBUG] [launch]: Traceback (most recent call last):
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 343, in run_async
    raise exception_to_raise
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 230, in _process_one_event
    await self.__process_event(next_event)
  File "/craftsman_dev/build/launch/launch/launch_service.py", line 250, in __process_event
    visit_all_entities_and_collect_futures(entity, self.__context))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
    sub_entities = entity.visit(context)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/action.py", line 107, in visit
    if self.__condition is None or self.__condition.evaluate(context):
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/condition.py", line 44, in evaluate
    return self._predicate(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/conditions/if_condition.py", line 43, in _predicate_func
    return evaluate_condition_expression(context, self.__predicate_expression)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/conditions/evaluate_condition_expression_impl.py", line 41, in evaluate_condition_expression
    expanded_expression = perform_substitutions(context, expression)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/utilities/perform_substitutions_impl.py", line 26, in perform_substitutions
    return ''.join([context.perform_substitution(sub) for sub in subs])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/launch_context.py", line 241, in perform_substitution
    return substitution.perform(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/craftsman_dev/build/launch/launch/substitutions/launch_configuration.py", line 98, in perform
    raise SubstitutionFailure(
launch.substitutions.substitution_failure.SubstitutionFailure: launch configuration 'start_quadruped_controller' does not exist

[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'start_quadruped_controller' does not exist
```