### PR TITLE
Changed control parameters for spot

### DIFF
--- a/champ_bringup/config/champ_params_spot_arm.yaml
+++ b/champ_bringup/config/champ_params_spot_arm.yaml
@@ -4,9 +4,9 @@
       knee_orientation: ">>"
       pantograph_leg: false
       odom_scaler: 0.9
-      max_linear_velocity_x: 0.20 #0.50
-      max_linear_velocity_y: 0.25
-      max_angular_velocity_z: 1.0
+      max_linear_velocity_x: 1.0 #0.50
+      max_linear_velocity_y: 1.0
+      max_angular_velocity_z: 4.0
       com_x_translation: 0.0
       swing_height: 0.04 #0.04
       stance_depth: 0.002 #0.00 

--- a/champ_bringup/config/ros2_control_spot.yaml
+++ b/champ_bringup/config/ros2_control_spot.yaml
@@ -37,7 +37,7 @@ joint_trajectory_controller:
       - velocity
 
     allow_partial_joints_goal: false # Defaults to false
-    open_loop_control: true
+    open_loop_control: false
     allow_integration_in_goal_trajectories: false
     constraints:
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01


### PR DESCRIPTION
Increased the max velocities as they were lower then what was being used in the other repositories. This made it so that the robot could get to the speed that it needed to to keep up with where it was supposed to be at the different points of time. Additionally changed the loop from a open loop to an closed loop so the feedback can further help the robot stabilize.